### PR TITLE
[fix] Sync Scoop path state

### DIFF
--- a/src-tauri/src/commands/installed.rs
+++ b/src-tauri/src/commands/installed.rs
@@ -184,9 +184,7 @@ async fn refresh_scoop_path_if_needed<R: Runtime>(
                     new_path.display(),
                     reason
                 );
-                state.set_scoop_path(new_path.clone());
-                let mut cache_guard = state.installed_packages.lock().await;
-                *cache_guard = None;
+                state.set_scoop_path(new_path.clone()).await;
                 return Some(new_path);
             }
             Some(current_path)

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,8 +1,9 @@
 //! Commands for reading and writing application settings from the persistent store.
+use crate::state::AppState;
 use serde_json::{Map, Value};
 use std::fs;
 use std::path::PathBuf;
-use tauri::{AppHandle, Runtime};
+use tauri::{AppHandle, Runtime, State};
 use tauri_plugin_store::{Store, StoreExt};
 
 const STORE_PATH: &str = "store.json";
@@ -80,12 +81,23 @@ pub fn get_scoop_path<R: Runtime>(app: AppHandle<R>) -> Result<Option<String>, S
     })
 }
 
-/// Sets the Scoop path in the store.
-#[tauri::command]
-pub fn set_scoop_path<R: Runtime>(app: AppHandle<R>, path: String) -> Result<(), String> {
+pub(crate) fn persist_scoop_path<R: Runtime>(app: AppHandle<R>, path: &str) -> Result<(), String> {
+    let path = path.to_string();
     with_store_mut(app, move |store| {
         store.set("scoop_path", serde_json::json!(path))
     })
+}
+
+/// Sets the Scoop path in the store and synchronizes runtime state.
+#[tauri::command]
+pub async fn set_scoop_path<R: Runtime>(
+    app: AppHandle<R>,
+    state: State<'_, AppState>,
+    path: String,
+) -> Result<(), String> {
+    persist_scoop_path(app, &path)?;
+    state.set_scoop_path(PathBuf::from(path)).await;
+    Ok(())
 }
 
 /// Gets a generic configuration value from the store by its key.

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -49,8 +49,26 @@ impl AppState {
     }
 
     /// Updates the Scoop root path stored in the application state.
-    pub fn set_scoop_path(&self, new_path: PathBuf) {
-        *self.scoop_path.write().unwrap_or_else(|e| e.into_inner()) = new_path;
+    ///
+    /// Returns whether the path changed. When it does, path-dependent caches
+    /// are cleared so later reads cannot use packages from the old Scoop root.
+    pub async fn set_scoop_path(&self, new_path: PathBuf) -> bool {
+        let changed = {
+            let mut current_path = self.scoop_path.write().unwrap_or_else(|e| e.into_inner());
+            if *current_path == new_path {
+                false
+            } else {
+                *current_path = new_path;
+                true
+            }
+        };
+
+        if changed {
+            *self.installed_packages.lock().await = None;
+            *self.package_versions.lock().await = None;
+        }
+
+        changed
     }
 
     /// Claims an explicit refresh slot. Returns false when the caller is
@@ -71,5 +89,53 @@ impl AppState {
 
         *last_refresh = Some(now);
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AppState, InstalledPackagesCache, PackageVersionsCache};
+    use crate::models::ScoopPackage;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    #[tokio::test]
+    async fn set_scoop_path_clears_path_dependent_caches_on_change() {
+        let state = AppState::new(PathBuf::from("C:\\scoop-old"));
+        seed_caches(&state).await;
+
+        let changed = state.set_scoop_path(PathBuf::from("D:\\scoop-new")).await;
+
+        assert!(changed);
+        assert_eq!(state.scoop_path(), PathBuf::from("D:\\scoop-new"));
+        assert!(state.installed_packages.lock().await.is_none());
+        assert!(state.package_versions.lock().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn set_scoop_path_keeps_caches_when_path_is_unchanged() {
+        let state = AppState::new(PathBuf::from("C:\\scoop"));
+        seed_caches(&state).await;
+
+        let changed = state.set_scoop_path(PathBuf::from("C:\\scoop")).await;
+
+        assert!(!changed);
+        assert!(state.installed_packages.lock().await.is_some());
+        assert!(state.package_versions.lock().await.is_some());
+    }
+
+    async fn seed_caches(state: &AppState) {
+        *state.installed_packages.lock().await = Some(InstalledPackagesCache {
+            packages: vec![ScoopPackage {
+                name: "example".to_string(),
+                ..Default::default()
+            }],
+            fingerprint: "fingerprint".to_string(),
+        });
+
+        *state.package_versions.lock().await = Some(PackageVersionsCache {
+            fingerprint: "fingerprint".to_string(),
+            versions_map: HashMap::from([("example".to_string(), vec!["1.0.0".to_string()])]),
+        });
     }
 }

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -322,9 +322,7 @@ pub fn resolve_scoop_root<R: Runtime>(app: AppHandle<R>) -> Result<PathBuf, Stri
             best.installed_count
         );
 
-        if let Err(e) =
-            settings::set_scoop_path(app.clone(), best_path.to_string_lossy().to_string())
-        {
+        if let Err(e) = settings::persist_scoop_path(app.clone(), &best_path.to_string_lossy()) {
             log::warn!(
                 "Failed to persist detected Scoop path '{}': {}",
                 best_path.display(),


### PR DESCRIPTION
## Summary
  - keep runtime AppState scoop_path synchronized when saving the Scoop path setting
  - clear installed-package and package-version caches when the Scoop root changes
  - reuse the same cache-safe state transition during auto path refresh
  - add AppState tests for changed and unchanged path behavior

  ## Validation
  - cargo test
  - cargo check
  - npm run build