### PR TITLE
Add shell.pwshEnabled hidden setting to run Scoop commands via pwsh

### DIFF
--- a/src-tauri/src/commands/profile.rs
+++ b/src-tauri/src/commands/profile.rs
@@ -133,6 +133,7 @@ const RSCOOP_SETTING_KEYS: &[&str] = &[
     "buckets.autoUpdateInterval",
     "buckets.autoUpdatePackagesEnabled",
     "operations.backgroundByDefault",
+    "shell.pwshEnabled",
 ];
 
 fn read_scoop_config_file() -> Result<Map<String, Value>, String> {

--- a/src-tauri/src/commands/scoop.rs
+++ b/src-tauri/src/commands/scoop.rs
@@ -25,7 +25,7 @@ where
         "Import-Module Microsoft.PowerShell.Utility -EA SilentlyContinue; scoop {}",
         args
     );
-    if is_pwsh_enabled(app.clone()) {
+    if is_pwsh_enabled(app) {
         execra::Command::pwsh(inner).tags(["scoop".to_string()])
     } else {
         execra::Command::powershell(inner).tags(["scoop".to_string()])

--- a/src-tauri/src/commands/scoop.rs
+++ b/src-tauri/src/commands/scoop.rs
@@ -3,13 +3,15 @@ use execra::Outcome;
 use tauri::AppHandle;
 
 use crate::commands::scoop_interpreter::{is_creep_phase, phase_range, scoop_interpreter};
+use crate::commands::settings::is_pwsh_enabled;
 use crate::operations::{self, OperationWarning};
 
 fn ps_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
 }
 
-pub fn scoop_cmd<I, S>(args: I) -> execra::Command
+
+pub fn scoop_cmd<I, S>(app: AppHandle, args: I) -> execra::Command
 where
     I: IntoIterator<Item = S>,
     S: AsRef<str>,
@@ -23,7 +25,11 @@ where
         "Import-Module Microsoft.PowerShell.Utility -EA SilentlyContinue; scoop {}",
         args
     );
-    execra::Command::powershell(inner).tags(["scoop".to_string()])
+    if is_pwsh_enabled(app.clone()) {
+        execra::Command::pwsh(inner).tags(["scoop".to_string()])
+    } else {
+        execra::Command::powershell(inner).tags(["scoop".to_string()])
+    }
 }
 
 /// Supported Scoop operations.
@@ -188,13 +194,10 @@ async fn execute_scoop_labeled_outcome(
 ) -> Result<(Outcome, String), String> {
     let args = build_scoop_args(op, package, bucket)?;
     let label = operation_name(op, package)?;
-    let outcome = run_operation(
-        app,
-        scoop_cmd(args)
-            .label(label.clone())
-            .interpreter(scoop_interpreter()),
-    )
-    .await?;
+    let cmd = scoop_cmd(app.clone(), args)
+        .label(label.clone())
+        .interpreter(scoop_interpreter());
+    let outcome = run_operation(app, cmd).await?;
     Ok((outcome, label))
 }
 
@@ -229,11 +232,8 @@ pub async fn run_scoop_operation(
     args: Vec<String>,
     label: impl Into<String>,
 ) -> Result<Outcome, String> {
-    run_operation(
-        app,
-        scoop_cmd(args)
-            .label(label.into())
-            .interpreter(scoop_interpreter()),
-    )
-    .await
+    let cmd = scoop_cmd(app.clone(), args)
+        .label(label.into())
+        .interpreter(scoop_interpreter());
+    run_operation(app, cmd).await
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -100,6 +100,16 @@ pub async fn set_scoop_path<R: Runtime>(
     Ok(())
 }
 
+pub(crate) fn is_pwsh_enabled<R: Runtime>(app: AppHandle<R>) -> bool {
+    with_store_get(app, |store| {
+        store
+            .get("shell.pwshEnabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    })
+    .unwrap_or(false)
+}
+
 /// Gets a generic configuration value from the store by its key.
 #[tauri::command]
 pub fn get_config_value<R: Runtime>(

--- a/src-tauri/src/commands/virustotal.rs
+++ b/src-tauri/src/commands/virustotal.rs
@@ -54,10 +54,10 @@ pub async fn run_scan(
         None => package_name.to_string(),
     };
 
+    let cmd = scoop_cmd(app.clone(), ["virustotal".to_string(), target]);
     run_operation(
         app,
-        scoop_cmd(["virustotal".to_string(), target])
-            .label(format!("Scanning {} with VirusTotal", package_name))
+        cmd.label(format!("Scanning {} with VirusTotal", package_name))
             .interpreter(VirusTotalInterpreter),
     )
     .await


### PR DESCRIPTION
## Summary
- Add `shell.pwshEnabled` key to the persistent store (default: `false`)
- When enabled, Scoop commands run via `pwsh` (PowerShell 7+) instead of `powershell` (PowerShell 5.x)

## How to enable
Edit `%APPDATA%\com.rscoop.app\store.json` and add: `"shell.pwshEnabled": true`

This PR fixes #54